### PR TITLE
fix: prefer ChatGPT OAuth account IDs

### DIFF
--- a/src/core/oauth/jwt.py
+++ b/src/core/oauth/jwt.py
@@ -81,9 +81,10 @@ def extract_account_id(token: str, raise_on_error: bool = False) -> str | None:
         TokenError: If raise_on_error is True and token is malformed
 
     The account ID may be found in:
-    1. https://api.openai.com/auth.user_id (OpenAI custom claim)
-    2. user_id (direct claim)
-    3. sub (standard subject claim)
+    1. https://api.openai.com/auth.chatgpt_account_id (ChatGPT account UUID)
+    2. https://api.openai.com/auth.user_id (OpenAI user ID)
+    3. user_id (direct claim)
+    4. sub (standard subject claim)
     """
     try:
         claims = parse_jwt_claims(token)
@@ -95,9 +96,13 @@ def extract_account_id(token: str, raise_on_error: bool = False) -> str | None:
     # Try OpenAI's custom claim first
     openai_auth = claims.get("https://api.openai.com/auth")
     if isinstance(openai_auth, dict):
-        account_id = openai_auth.get("user_id")
-        if isinstance(account_id, str):
-            return account_id
+        chatgpt_account_id = openai_auth.get("chatgpt_account_id")
+        if isinstance(chatgpt_account_id, str):
+            return chatgpt_account_id
+
+        user_id = openai_auth.get("user_id")
+        if isinstance(user_id, str):
+            return user_id
 
     # Try direct user_id claim
     account_id = claims.get("user_id")

--- a/tests/unit/test_oauth_jwt.py
+++ b/tests/unit/test_oauth_jwt.py
@@ -1,0 +1,32 @@
+import base64
+import json
+
+import pytest
+
+from src.core.oauth.jwt import extract_account_id
+
+
+def _encode_segment(payload: dict[str, str | dict[str, str]]) -> str:
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _jwt_with_claims(claims: dict[str, str | dict[str, str]]) -> str:
+    header = _encode_segment({"alg": "none"})
+    payload = _encode_segment(claims)
+    return f"{header}.{payload}.signature"
+
+
+@pytest.mark.unit
+def test_extract_account_id_prefers_chatgpt_account_id_over_user_id():
+    token = _jwt_with_claims(
+        {
+            "https://api.openai.com/auth": {
+    "chatgpt_account_id": "00000000-0000-4000-8000-000000000000",
+    "user_id": "user-testFixtureOnly000000000000000",
+            },
+            "sub": "auth0|fallback",
+        }
+    )
+
+    assert extract_account_id(token) == "00000000-0000-4000-8000-000000000000"


### PR DESCRIPTION
## Summary

- Prefer the ChatGPT account UUID claim when extracting OAuth account IDs.
- Fall back to the existing OpenAI user ID and standard claims when the ChatGPT claim is absent.
- Add a unit regression covering both claims.

## Test plan

- [x] uv run pytest tests/unit/test_oauth_jwt.py -q
- [x] uv run ruff check src/core/oauth/jwt.py tests/unit/test_oauth_jwt.py