### PR TITLE
fix: update ChatGPT Responses defaults

### DIFF
--- a/docs/oauth-guide.md
+++ b/docs/oauth-guide.md
@@ -28,7 +28,8 @@ Set the `AUTH_MODE` environment variable for your provider:
 
 ```bash
 export CHATGPT_AUTH_MODE=oauth
-export CHATGPT_BASE_URL=https://api.openai.com/v1
+export CHATGPT_BASE_URL=https://chatgpt.com/backend-api/codex
+export CHATGPT_API_FORMAT=responses
 export VDM_DEFAULT_TARGET=chatgpt
 ```
 
@@ -36,7 +37,8 @@ Alternatively, use the `!OAUTH` sentinel value:
 
 ```bash
 export CHATGPT_API_KEY=!OAUTH
-export CHATGPT_BASE_URL=https://api.openai.com/v1
+export CHATGPT_BASE_URL=https://chatgpt.com/backend-api/codex
+export CHATGPT_API_FORMAT=responses
 ```
 
 Or configure via TOML in `~/.config/vandamme-proxy/vandamme-config.toml`:
@@ -44,7 +46,8 @@ Or configure via TOML in `~/.config/vandamme-proxy/vandamme-config.toml`:
 ```toml
 [chatgpt]
 auth-mode = "oauth"
-base-url = "https://api.openai.com/v1"
+api-format = "responses"
+base-url = "https://chatgpt.com/backend-api/codex"
 ```
 
 ### Step 2: Authenticate
@@ -72,7 +75,7 @@ This will:
 ┃ [green]✅ Successfully authenticated![/green]  ┃
 ┃                                          ┃
 ┃ Provider: chatgpt                        ┃
-┃ Account ID: user_abc123xyz               ┃
+┃ Account ID: 00000000-0000-4000-8000-000000000000 ┃
 ┃ Token expires at: 2026-01-17T12:34:56Z   ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 ```
@@ -94,7 +97,7 @@ vdm oauth status chatgpt
 ├─────────────────────────────────────────────────────┨
 ┃ Provider           chatgpt                          ┃
 ┃ Status             [green]✅ Authenticated[/green]  ┃
-┃ Account ID         user_abc123xyz                   ┃
+┃ Account ID         00000000-0000-4000-8000-000000000000 ┃
 ┃ Expires At         2026-01-17T12:34:56Z             ┃
 ┃ Last Refresh       2026-01-16T10:15:30Z             ┃
 ┃ Storage Path       /home/user/.vandamme/oauth/chatgpt/ ┃
@@ -110,7 +113,7 @@ vdm server start
 ### Step 5: Use with Claude Code
 
 ```bash
-ANTHROPIC_BASE_URL=http://localhost:8082 claude "Hello, world!"
+ANTHROPIC_BASE_URL=http://localhost:8082 claude --model gpt-5.4 "Hello, world!"
 ```
 
 ## Configuration Methods

--- a/src/config/defaults.toml
+++ b/src/config/defaults.toml
@@ -115,10 +115,10 @@ auth-mode = "oauth"
 timeout = 300
 max-retries = 2
 [chatgpt.aliases]
-# Confirmed working via spike test (2026-03-25). Model availability may change.
-haiku = "gpt-5"
-sonnet = "gpt-5.2-codex"
-opus = "gpt-5.2"
+# Confirmed working via local probe (2026-07-02). Model availability may change.
+haiku = "gpt-5.4"
+sonnet = "gpt-5.5"
+opus = "gpt-5.5"
 
 # Cursor Agent provider — uses agent-cli-to-api bridge on localhost.
 # Requires: `agent-cli-to-api cursor-agent` running on port 8766.
@@ -403,4 +403,3 @@ kimi = "kimi-k2.6"
 mimo = "mimo-v2.5-pro"
 minimax = "minimax-m2.7"
 qwen = "qwen3.6-plus"
-

--- a/src/core/responses_client.py
+++ b/src/core/responses_client.py
@@ -387,7 +387,7 @@ class ResponsesAPIClient(OAuthClientMixin):
         if "not supported" in error_str:
             return (
                 "Model not supported by ChatGPT Responses API. "
-                "Use a ChatGPT-compatible model (e.g., gpt-5, gpt-5.2-codex)."
+                "Use a ChatGPT-compatible model (e.g., gpt-5.4, gpt-5.5)."
             )
         if "instructions are required" in error_str:
             return (

--- a/tests/integration/test_chatgpt_responses.py
+++ b/tests/integration/test_chatgpt_responses.py
@@ -64,9 +64,7 @@ from tests.config import TEST_HEADERS
 _CHATGPT_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _RESPONSES_API_URL = f"{_CHATGPT_BASE_URL}/responses"
 
-# Model name to use in Claude requests — must match a known chatgpt alias or
-# a valid Responses API model name.  "gpt-5" is the haiku alias in defaults.toml.
-_CHATGPT_MODEL = "chatgpt:gpt-5"
+_CHATGPT_MODEL = "chatgpt:gpt-5.4"
 
 # Fake OAuth credentials (never used for real HTTP calls — RESPX intercepts)
 _FAKE_ACCESS_TOKEN = "fake_oauth_access_token_for_testing"
@@ -137,6 +135,7 @@ def chatgpt_provider_env() -> Generator[None, None, None]:
     modules_to_clear = [
         "src.core.config",
         "src.core.dependencies",
+        "src.core.provider",
         "src.core.provider_manager",
         "src.core.provider.client_factory",
         "src.main",


### PR DESCRIPTION
## Summary

- Point ChatGPT OAuth examples at the ChatGPT Codex Responses endpoint.
- Update built-in ChatGPT aliases and user-facing error guidance to current working models.
- Keep the ChatGPT Responses integration fixture aligned with the defaults.

## Test plan

- [x] uv run pytest tests/integration/test_chatgpt_responses.py -q
- [x] uv run ruff check src/config/defaults.toml src/core/responses_client.py tests/integration/test_chatgpt_responses.py