### PR TITLE
docs: document Claude Code gateway discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,21 @@ uv tool install vandamme-proxy
 # Configure 1 or multiple API keys for production resilience
 export POE_API_KEY="sk-key1 sk-key2 sk-key3"
 
-# Run Claude Code CLI wrapped by Vandamme
-claude.vdm
+# Configure Claude Code to discover gateway models through Vandamme
+# (enables CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY and Vandamme base URLs)
+vdm claude-code setup
+
+# Start Claude Code with generic Vandamme aliases or model picker entries
+claude --model sonnet
 
 # Open dashboard page for monitoring
 open http://localhost:8082/dashboard/
 ```
 
 ```shell
-`# Use with Claude Code CLI
-export ANTHROPIC_BASE_URL=http://localhost:8082
-claude --model openai:gpt-4o "Analyze this code"
-claude --model poe:gemini-flash "Quick question"
-claude --model fast "Fast response"  # Smart alias
+# Or run Claude Code CLI wrapped by Vandamme for a single session
+claude.vdm --model sonnet
+claude.vdm --model haiku "Fast response"
 ```
 
 ### For LLM Gateway Users
@@ -181,20 +183,31 @@ vdm server start --host 0.0.0.0 --port 8082
 ### 4️⃣ Use with Claude Code CLI
 
 ```bash
-# Point Claude Code to proxy
-export ANTHROPIC_BASE_URL=http://localhost:8082
+# Safely merge Vandamme settings into ~/.claude/settings.json
+# Enables gateway model discovery and uses provider-agnostic aliases:
+# model=sonnet, small/fast=haiku
+vdm claude-code setup
 
-# Use provider routing
-claude --model openai:gpt-4o "Analyze this code"
-claude --model poe:gemini-flash "Quick question"
+# If your proxy requires client auth, include the token/key
+vdm claude-code setup --api-key your-proxy-key
 
-# Use smart aliases
-claude --model fast "Fast response needed"
-claude --model chat "Deep conversation"
+# Use generic aliases, provider-prefixed models, or Claude Code's model picker
+claude --model sonnet "Analyze this code"
+claude --model haiku "Quick question"
+claude --model openai:gpt-4o "Use a specific provider/model"
 
-# For passthrough providers (!PASSTHRU), provide your API key
+# For passthrough providers (!PASSTHRU), provide your upstream API key
 ANTHROPIC_API_KEY=your-poe-key claude --model poe:gemini-flash "..."
 ```
+
+`vdm claude-code setup` writes these Claude Code environment keys:
+
+- `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`
+- `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_BASE_URL`, and `CLAUDE_AGENT_API_BASE_URL` pointing to Vandamme
+- `ANTHROPIC_MODEL=sonnet` and `ANTHROPIC_SMALL_FAST_MODEL=haiku` by default
+- Optional `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN` when passed
+
+Restart Claude Code after changing these settings.
 
 ### 5️⃣ Verify Your Setup
 
@@ -594,6 +607,19 @@ LOG_LEVEL=INFO                  # Logging level
 MAX_TOKENS_LIMIT=4096           # Maximum tokens
 REQUEST_TIMEOUT=90              # Request timeout in seconds
 MAX_RETRIES=2                   # Retry attempts
+```
+
+#### ChatGPT OAuth Provider Example
+
+ChatGPT can be configured as one possible provider using OAuth, but it is not required for the generic Claude Code quickstart.
+
+```bash
+export CHATGPT_AUTH_MODE=oauth
+export CHATGPT_BASE_URL=https://api.openai.com/v1
+export VDM_DEFAULT_TARGET=chatgpt
+vdm oauth login chatgpt
+vdm server start
+vdm claude-code setup --model sonnet --small-fast-model haiku
 ```
 
 #### Middleware Configuration

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ vdm server start --host 0.0.0.0 --port 8082
 vdm claude-code setup
 
 # If your proxy requires client auth, include the token/key
-# (the value is written to settings.json but redacted from --dry-run output)
+# (--dry-run shows only the Vandamme env delta and redacts secret-like keys)
 vdm claude-code setup --api-key your-proxy-key
 
 # Use generic aliases, provider-prefixed models, or Claude Code's model picker

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ vdm server start --host 0.0.0.0 --port 8082
 vdm claude-code setup
 
 # If your proxy requires client auth, include the token/key
+# (the value is written to settings.json but redacted from --dry-run output)
 vdm claude-code setup --api-key your-proxy-key
 
 # Use generic aliases, provider-prefixed models, or Claude Code's model picker

--- a/src/cli/commands/claude_code.py
+++ b/src/cli/commands/claude_code.py
@@ -1,0 +1,191 @@
+"""Claude Code integration commands."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+
+app = typer.Typer(help="Claude Code integration")
+
+DEFAULT_BASE_URL = "http://localhost:8082"
+DEFAULT_MODEL = "sonnet"
+DEFAULT_SMALL_FAST_MODEL = "haiku"
+
+
+def default_settings_path() -> Path:
+    """Return the default Claude Code settings path."""
+    return Path.home() / ".claude" / "settings.json"
+
+
+def load_settings(path: Path) -> dict[str, Any]:
+    """Load Claude Code settings, returning an empty settings object when absent."""
+    if not path.exists():
+        return {}
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path} is not valid JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def build_claude_code_env(
+    *,
+    base_url: str,
+    model: str,
+    small_fast_model: str,
+    auth_token: str | None = None,
+    api_key: str | None = None,
+) -> dict[str, str]:
+    """Build the environment entries Claude Code needs for Vandamme."""
+    env = {
+        "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "1",
+        "ANTHROPIC_BASE_URL": base_url,
+        "ANTHROPIC_API_BASE_URL": base_url,
+        "CLAUDE_AGENT_API_BASE_URL": base_url,
+        "ANTHROPIC_MODEL": model,
+        "ANTHROPIC_SMALL_FAST_MODEL": small_fast_model,
+    }
+    if auth_token:
+        env["ANTHROPIC_AUTH_TOKEN"] = auth_token
+    if api_key:
+        env["ANTHROPIC_API_KEY"] = api_key
+    return env
+
+
+def merge_settings(
+    existing: dict[str, Any],
+    new_env: dict[str, str],
+    *,
+    force: bool = False,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Merge Vandamme env settings into an existing Claude Code settings object.
+
+    Returns the merged settings and a mapping of skipped keys. Keys are skipped
+    when they already exist with a different value and ``force`` is false.
+    """
+    merged = dict(existing)
+    existing_env = merged.get("env", {})
+    if existing_env is None:
+        existing_env = {}
+    if not isinstance(existing_env, dict):
+        raise ValueError("settings.json field 'env' must be a JSON object when present")
+
+    env = dict(existing_env)
+    skipped: dict[str, str] = {}
+    for key, value in new_env.items():
+        current = env.get(key)
+        if current is not None and current != value and not force:
+            skipped[key] = str(current)
+            continue
+        env[key] = value
+
+    merged["env"] = env
+    return merged, skipped
+
+
+def write_settings(path: Path, settings: dict[str, Any]) -> None:
+    """Write Claude Code settings atomically enough for local CLI use."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(settings, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+@app.command()
+def setup(
+    base_url: str = typer.Option(
+        DEFAULT_BASE_URL,
+        "--base-url",
+        help="Vandamme proxy base URL for Claude Code requests and gateway model discovery.",
+    ),
+    model: str = typer.Option(
+        DEFAULT_MODEL,
+        "--model",
+        help="Default Claude Code model. Defaults to Vandamme's generic alias.",
+    ),
+    small_fast_model: str = typer.Option(
+        DEFAULT_SMALL_FAST_MODEL,
+        "--small-fast-model",
+        help="Claude Code small/fast model. Defaults to Vandamme's generic alias.",
+    ),
+    auth_token: str | None = typer.Option(
+        None,
+        "--auth-token",
+        help="Optional proxy auth token to write as ANTHROPIC_AUTH_TOKEN.",
+    ),
+    api_key: str | None = typer.Option(
+        None,
+        "--api-key",
+        help="Optional proxy API key to write as ANTHROPIC_API_KEY.",
+    ),
+    settings_path: Path | None = typer.Option(
+        None,
+        "--settings-path",
+        help="Claude Code settings.json path. Primarily useful for tests.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print the merged settings without writing files.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Overwrite existing Claude Code Vandamme-related env values.",
+    ),
+) -> None:
+    """Configure Claude Code to use Vandamme for model discovery and requests.
+
+    The command updates ``~/.claude/settings.json`` by merging the ``env`` object;
+    existing unrelated Claude Code settings are preserved. It enables Claude Code's
+    gateway model discovery and points all known Claude Code gateway base URL env
+    keys at Vandamme. Existing Claude Code/Vandamme env values are left unchanged
+    unless ``--force`` is passed.
+    """
+    console = Console()
+    path = settings_path or Path(os.environ.get("CLAUDE_SETTINGS_PATH", default_settings_path()))
+
+    try:
+        existing = load_settings(path)
+        new_env = build_claude_code_env(
+            base_url=base_url,
+            model=model,
+            small_fast_model=small_fast_model,
+            auth_token=auth_token,
+            api_key=api_key,
+        )
+        merged, skipped = merge_settings(existing, new_env, force=force)
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from None
+
+    if dry_run:
+        console.print(json.dumps(merged, indent=2, sort_keys=True))
+    else:
+        write_settings(path, merged)
+        console.print(f"[green]✅ Claude Code settings updated:[/green] {path}")
+
+    if skipped:
+        skipped_list = ", ".join(sorted(skipped))
+        console.print(
+            Panel(
+                f"Preserved existing values for: {skipped_list}\n"
+                "Run again with --force to overwrite these keys.",
+                title="Existing Claude Code env preserved",
+                style="yellow",
+            )
+        )
+
+    console.print(
+        "[dim]Configured env keys: "
+        + ", ".join(key for key in sorted(new_env) if key not in skipped)
+        + "[/dim]"
+    )

--- a/src/cli/commands/claude_code.py
+++ b/src/cli/commands/claude_code.py
@@ -94,15 +94,18 @@ def merge_settings(
     return merged, skipped
 
 
-def redact_settings_for_display(settings: dict[str, Any]) -> dict[str, Any]:
-    """Return settings safe for terminal display by redacting secret env values."""
-    redacted = copy.deepcopy(settings)
-    env = redacted.get("env")
-    if isinstance(env, dict):
-        for key in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"):
-            if key in env:
-                env[key] = "***"
-    return redacted
+SECRET_ENV_MARKERS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL")
+
+
+def is_secret_env_key(key: str) -> bool:
+    """Return true when an environment key name conventionally carries a secret."""
+    upper_key = key.upper()
+    return any(marker in upper_key for marker in SECRET_ENV_MARKERS)
+
+
+def redact_env_for_display(env: dict[str, str]) -> dict[str, str]:
+    """Return env entries safe for terminal display by redacting secret-like keys."""
+    return {key: "***" if is_secret_env_key(key) else value for key, value in env.items()}
 
 
 def write_settings(path: Path, settings: dict[str, Any]) -> None:
@@ -180,7 +183,19 @@ def setup(
         raise typer.Exit(1) from None
 
     if dry_run:
-        console.print(json.dumps(redact_settings_for_display(merged), indent=2, sort_keys=True))
+        typer.echo(
+            json.dumps(
+                {
+                    "settings_path": str(path),
+                    "env": redact_env_for_display(
+                        {key: value for key, value in new_env.items() if key not in skipped}
+                    ),
+                    "skipped_env_keys": sorted(skipped),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
     else:
         write_settings(path, merged)
         console.print(f"[green]✅ Claude Code settings updated:[/green] {path}")

--- a/src/cli/commands/claude_code.py
+++ b/src/cli/commands/claude_code.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 from pathlib import Path
@@ -67,13 +68,13 @@ def merge_settings(
     new_env: dict[str, str],
     *,
     force: bool = False,
-) -> tuple[dict[str, Any], dict[str, str]]:
+) -> tuple[dict[str, Any], set[str]]:
     """Merge Vandamme env settings into an existing Claude Code settings object.
 
-    Returns the merged settings and a mapping of skipped keys. Keys are skipped
+    Returns the merged settings and the names of skipped keys. Keys are skipped
     when they already exist with a different value and ``force`` is false.
     """
-    merged = dict(existing)
+    merged = copy.deepcopy(existing)
     existing_env = merged.get("env", {})
     if existing_env is None:
         existing_env = {}
@@ -81,16 +82,27 @@ def merge_settings(
         raise ValueError("settings.json field 'env' must be a JSON object when present")
 
     env = dict(existing_env)
-    skipped: dict[str, str] = {}
+    skipped: set[str] = set()
     for key, value in new_env.items():
         current = env.get(key)
         if current is not None and current != value and not force:
-            skipped[key] = str(current)
+            skipped.add(key)
             continue
         env[key] = value
 
     merged["env"] = env
     return merged, skipped
+
+
+def redact_settings_for_display(settings: dict[str, Any]) -> dict[str, Any]:
+    """Return settings safe for terminal display by redacting secret env values."""
+    redacted = copy.deepcopy(settings)
+    env = redacted.get("env")
+    if isinstance(env, dict):
+        for key in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"):
+            if key in env:
+                env[key] = "***"
+    return redacted
 
 
 def write_settings(path: Path, settings: dict[str, Any]) -> None:
@@ -168,7 +180,7 @@ def setup(
         raise typer.Exit(1) from None
 
     if dry_run:
-        console.print(json.dumps(merged, indent=2, sort_keys=True))
+        console.print(json.dumps(redact_settings_for_display(merged), indent=2, sort_keys=True))
     else:
         write_settings(path, merged)
         console.print(f"[green]✅ Claude Code settings updated:[/green] {path}")
@@ -177,7 +189,7 @@ def setup(
         skipped_list = ", ".join(sorted(skipped))
         console.print(
             Panel(
-                f"Preserved existing values for: {skipped_list}\n"
+                f"Preserved existing values for keys: {skipped_list}\n"
                 "Run again with --force to overwrite these keys.",
                 title="Existing Claude Code env preserved",
                 style="yellow",

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -7,7 +7,7 @@ import sys
 import typer
 
 # Import command modules
-from src.cli.commands import config, debug, health, models, oauth, server, test
+from src.cli.commands import claude_code, config, debug, health, models, oauth, server, test
 from src.cli.commands.wrap import wrap
 
 app = typer.Typer(
@@ -25,6 +25,7 @@ app.add_typer(models.app, name="models", help="Model discovery")
 app.add_typer(test.app, name="test", help="Test commands")
 app.add_typer(debug.app, name="debug", help="Debug and diagnostic commands")
 app.add_typer(oauth.app, name="oauth", help="OAuth authentication management")
+app.add_typer(claude_code.app, name="claude-code", help="Claude Code integration")
 
 # Add wrap as a command directly with support for extra arguments
 app.command(context_settings={"allow_extra_args": True})(wrap)

--- a/tests/unit/test_cli_claude_code.py
+++ b/tests/unit/test_cli_claude_code.py
@@ -1,0 +1,174 @@
+"""Unit tests for the ``vdm claude-code setup`` CLI command."""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+from typer.testing import CliRunner
+
+from src.cli.commands.claude_code import DEFAULT_MODEL, DEFAULT_SMALL_FAST_MODEL
+from src.cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.mark.unit
+def test_setup_merges_env_and_preserves_existing_settings(tmp_path) -> None:
+    """Existing settings and env keys should be preserved while Vandamme keys are added."""
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "permissions": {"allow": ["Bash(make test-unit)"]},
+                "env": {"EXISTING": "keep-me"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["claude-code", "setup", "--settings-path", str(settings_path)])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert data["permissions"] == {"allow": ["Bash(make test-unit)"]}
+    assert data["env"]["EXISTING"] == "keep-me"
+    assert data["env"]["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
+    assert data["env"]["ANTHROPIC_BASE_URL"] == "http://localhost:8082"
+    assert data["env"]["ANTHROPIC_API_BASE_URL"] == "http://localhost:8082"
+    assert data["env"]["CLAUDE_AGENT_API_BASE_URL"] == "http://localhost:8082"
+    assert data["env"]["ANTHROPIC_MODEL"] == "sonnet"
+    assert data["env"]["ANTHROPIC_SMALL_FAST_MODEL"] == "haiku"
+
+
+@pytest.mark.unit
+def test_setup_dry_run_does_not_write_file(tmp_path) -> None:
+    """Dry-run should show the merged JSON but not create or mutate settings.json."""
+    settings_path = tmp_path / "missing" / "settings.json"
+
+    result = runner.invoke(
+        app,
+        ["claude-code", "setup", "--settings-path", str(settings_path), "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert not settings_path.exists()
+    plain_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    rendered = json.loads(plain_output.split("\nConfigured env keys:")[0])
+    assert rendered["env"]["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
+    assert rendered["env"]["ANTHROPIC_API_BASE_URL"] == "http://localhost:8082"
+    assert rendered["env"]["CLAUDE_AGENT_API_BASE_URL"] == "http://localhost:8082"
+    assert rendered["env"]["ANTHROPIC_MODEL"] == DEFAULT_MODEL
+    assert rendered["env"]["ANTHROPIC_SMALL_FAST_MODEL"] == DEFAULT_SMALL_FAST_MODEL
+
+
+@pytest.mark.unit
+def test_setup_uses_generic_defaults_not_provider_specific(tmp_path) -> None:
+    """Defaults should enable generic Vandamme gateway discovery aliases."""
+    settings_path = tmp_path / "settings.json"
+
+    result = runner.invoke(app, ["claude-code", "setup", "--settings-path", str(settings_path)])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert data["env"]["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
+    assert data["env"]["ANTHROPIC_BASE_URL"] == "http://localhost:8082"
+    assert data["env"]["ANTHROPIC_API_BASE_URL"] == "http://localhost:8082"
+    assert data["env"]["CLAUDE_AGENT_API_BASE_URL"] == "http://localhost:8082"
+    assert data["env"]["ANTHROPIC_MODEL"] == "sonnet"
+    assert data["env"]["ANTHROPIC_SMALL_FAST_MODEL"] == "haiku"
+    assert "chatgpt" not in json.dumps(data).lower()
+
+
+@pytest.mark.unit
+def test_setup_honors_custom_base_url_for_all_gateway_keys(tmp_path) -> None:
+    """Custom base URL should be applied to each known Claude Code gateway URL key."""
+    settings_path = tmp_path / "settings.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "claude-code",
+            "setup",
+            "--settings-path",
+            str(settings_path),
+            "--base-url",
+            "http://127.0.0.1:9090",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert data["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:9090"
+    assert data["env"]["ANTHROPIC_API_BASE_URL"] == "http://127.0.0.1:9090"
+    assert data["env"]["CLAUDE_AGENT_API_BASE_URL"] == "http://127.0.0.1:9090"
+
+
+@pytest.mark.unit
+def test_setup_preserves_existing_vandamme_keys_without_force(tmp_path) -> None:
+    """Existing Claude Code gateway env values should not be overwritten unless forced."""
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "ANTHROPIC_MODEL": "custom-existing-model",
+                    "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "0",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["claude-code", "setup", "--settings-path", str(settings_path)])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert data["env"]["ANTHROPIC_MODEL"] == "custom-existing-model"
+    assert data["env"]["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "0"
+    assert "Preserved existing values" in result.output
+
+
+@pytest.mark.unit
+def test_setup_force_overwrites_existing_vandamme_keys(tmp_path) -> None:
+    """--force should replace existing Claude Code gateway env values with requested values."""
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "ANTHROPIC_MODEL": "custom-existing-model",
+                    "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "0",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "claude-code",
+            "setup",
+            "--settings-path",
+            str(settings_path),
+            "--model",
+            "opus",
+            "--force",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert data["env"]["ANTHROPIC_MODEL"] == "opus"
+    assert data["env"]["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
+
+
+@pytest.mark.unit
+def test_claude_code_command_is_registered() -> None:
+    """The main CLI should expose the claude-code setup command."""
+    result = runner.invoke(app, ["claude-code", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "setup" in result.output

--- a/tests/unit/test_cli_claude_code.py
+++ b/tests/unit/test_cli_claude_code.py
@@ -56,6 +56,8 @@ def test_setup_dry_run_does_not_write_file(tmp_path) -> None:
     assert not settings_path.exists()
     plain_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
     rendered = json.loads(plain_output.split("\nConfigured env keys:")[0])
+    assert rendered["settings_path"] == str(settings_path)
+    assert rendered["skipped_env_keys"] == []
     assert rendered["env"]["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
     assert rendered["env"]["ANTHROPIC_API_BASE_URL"] == "http://localhost:8082"
     assert rendered["env"]["CLAUDE_AGENT_API_BASE_URL"] == "http://localhost:8082"
@@ -91,6 +93,8 @@ def test_setup_dry_run_redacts_secret_values(tmp_path) -> None:
     assert secret_token not in result.output
     plain_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
     rendered = json.loads(plain_output.split("\nConfigured env keys:")[0])
+    assert rendered["settings_path"] == str(settings_path)
+    assert rendered["skipped_env_keys"] == []
     assert rendered["env"]["ANTHROPIC_API_KEY"] == "***"
     assert rendered["env"]["ANTHROPIC_AUTH_TOKEN"] == "***"
 
@@ -175,6 +179,30 @@ def test_setup_preserves_existing_vandamme_keys_without_force(tmp_path) -> None:
     assert "Preserved existing values" in result.output
     assert secret_existing_key not in result.output
     assert "new-secret-key" not in result.output
+
+
+@pytest.mark.unit
+def test_setup_dry_run_only_shows_vandamme_delta_not_existing_env(tmp_path) -> None:
+    """Dry-run should not dump unrelated existing environment values."""
+    settings_path = tmp_path / "settings.json"
+    unrelated_secret = "unrelated-existing-secret"
+    settings_path.write_text(
+        json.dumps({"env": {"UNRELATED_SECRET": unrelated_secret, "EXISTING": "keep-me"}}),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["claude-code", "setup", "--settings-path", str(settings_path), "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert unrelated_secret not in result.output
+    plain_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    rendered = json.loads(plain_output.split("\nConfigured env keys:")[0])
+    assert "UNRELATED_SECRET" not in rendered["env"]
+    assert "EXISTING" not in rendered["env"]
+    assert rendered["env"]["ANTHROPIC_MODEL"] == DEFAULT_MODEL
 
 
 @pytest.mark.unit

--- a/tests/unit/test_cli_claude_code.py
+++ b/tests/unit/test_cli_claude_code.py
@@ -64,6 +64,38 @@ def test_setup_dry_run_does_not_write_file(tmp_path) -> None:
 
 
 @pytest.mark.unit
+def test_setup_dry_run_redacts_secret_values(tmp_path) -> None:
+    """Dry-run should not print sensitive proxy credentials."""
+    settings_path = tmp_path / "settings.json"
+    secret_key = "secret-proxy-key"
+    secret_token = "secret-proxy-token"
+
+    result = runner.invoke(
+        app,
+        [
+            "claude-code",
+            "setup",
+            "--settings-path",
+            str(settings_path),
+            "--api-key",
+            secret_key,
+            "--auth-token",
+            secret_token,
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert not settings_path.exists()
+    assert secret_key not in result.output
+    assert secret_token not in result.output
+    plain_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    rendered = json.loads(plain_output.split("\nConfigured env keys:")[0])
+    assert rendered["env"]["ANTHROPIC_API_KEY"] == "***"
+    assert rendered["env"]["ANTHROPIC_AUTH_TOKEN"] == "***"
+
+
+@pytest.mark.unit
 def test_setup_uses_generic_defaults_not_provider_specific(tmp_path) -> None:
     """Defaults should enable generic Vandamme gateway discovery aliases."""
     settings_path = tmp_path / "settings.json"
@@ -109,11 +141,13 @@ def test_setup_honors_custom_base_url_for_all_gateway_keys(tmp_path) -> None:
 def test_setup_preserves_existing_vandamme_keys_without_force(tmp_path) -> None:
     """Existing Claude Code gateway env values should not be overwritten unless forced."""
     settings_path = tmp_path / "settings.json"
+    secret_existing_key = "existing-secret-key"
     settings_path.write_text(
         json.dumps(
             {
                 "env": {
                     "ANTHROPIC_MODEL": "custom-existing-model",
+                    "ANTHROPIC_API_KEY": secret_existing_key,
                     "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY": "0",
                 }
             }
@@ -121,13 +155,26 @@ def test_setup_preserves_existing_vandamme_keys_without_force(tmp_path) -> None:
         encoding="utf-8",
     )
 
-    result = runner.invoke(app, ["claude-code", "setup", "--settings-path", str(settings_path)])
+    result = runner.invoke(
+        app,
+        [
+            "claude-code",
+            "setup",
+            "--settings-path",
+            str(settings_path),
+            "--api-key",
+            "new-secret-key",
+        ],
+    )
 
     assert result.exit_code == 0, result.output
     data = json.loads(settings_path.read_text(encoding="utf-8"))
     assert data["env"]["ANTHROPIC_MODEL"] == "custom-existing-model"
+    assert data["env"]["ANTHROPIC_API_KEY"] == secret_existing_key
     assert data["env"]["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "0"
     assert "Preserved existing values" in result.output
+    assert secret_existing_key not in result.output
+    assert "new-secret-key" not in result.output
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- Document how to configure Claude Code gateway model discovery for Vandamme.
- Add setup steps for chatgpt:gpt-5.4 and chatgpt:gpt-5.5 in the model picker.
- Add a Claude Code smoke-test command to the quick start verification section.

## Test plan

- [x] GIT_MASTER=1 git diff --check README.md